### PR TITLE
Update pydantic version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ deps = [
     "protobuf~=3.20",
     "jinja2>=3.1.2",
     "watchdog>=4.0.0",
-    "pydantic==1.10.14",
+    "pydantic>2",
     "pyzmq>=25.1.2",
     "pygithub>=2.3.0",
 ]


### PR DESCRIPTION
The current version in `rollback_aurora` gives me [this](https://stackoverflow.com/questions/78324666/i-get-the-error-importerror-cannot-import-name-model-validator-from-pydanti) error on Aurora.