### PR TITLE
Relax `pydantic` version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ deps = [
     "protobuf~=3.20",
     "jinja2>=3.1.2",
     "watchdog>=4.0.0",
-    "pydantic==1.10.14",
+    "pydantic>=1.10.14",
     "pyzmq>=25.1.2",
     "pygithub>=2.3.0",
 ]


### PR DESCRIPTION
This will pick up `pydantic` from frameworks instead of installing `1.10.14` (which is too old for
frameworks module to work). With this change, `shooting_workflow_smartredis` works on Aurora.